### PR TITLE
revolve slider bugs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -587,6 +587,10 @@ header nav ul li a:focus{
   display: inline-block;
 }
 
+.slider-content-margin {
+  margin-right: 12vw;
+}
+
 .slider-content span:before{
   content: '';
   width: 40px;

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
   </nav>
 </header>
 
-<div class="wrapper">
+<div class="wrapper bottom_120">
 
 <!-- SLIDER 
 ==================================================-->
@@ -87,8 +87,8 @@
   <!-- Swiper -->
   <div class="static-image" style="background-image:url(img/deepskill-slider.jpg)">
     <div class="slider-content">
-      <span>Sesiones 1 a 1 en Ingeniería de Software con</span>
-      <h1>Mentores Tech.</h1>
+      <span style="margin-right: 12vw;">Sesiones 1 a 1 en Ingeniería de Software con</span>
+      <h1 style="margin-right: 12vw;">Mentores Tech.</h1>
       <a href="#about" class="site-btn top_30">VER MÁS</a>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -87,8 +87,8 @@
   <!-- Swiper -->
   <div class="static-image" style="background-image:url(img/deepskill-slider.jpg)">
     <div class="slider-content">
-      <span style="margin-right: 12vw;">Sesiones 1 a 1 en Ingeniería de Software con</span>
-      <h1 style="margin-right: 12vw;">Mentores Tech.</h1>
+      <span class="slider-content-margin">Sesiones 1 a 1 en Ingeniería de Software con</span>
+      <h1 class="slider-content-margin">Mentores Tech.</h1>
       <a href="#about" class="site-btn top_30">VER MÁS</a>
     </div>
   </div>


### PR DESCRIPTION
I added the .bottom_120 class from the margin.css file (line 67) to the index.html wrapper on line 82. This creates a margin that gives the footer room to be displayed.

Add style="margin-right: 12vw;" in line 90 and 91 of the index.html. It is strange because in the slider.html file the slider has a different implementation.
This way, the span and h1 change the rendering with the @screen in time. (It was done in the span because it has the same bug in the Samsung Galaxy S8+ test in Chrome.)

Test changes on different screens before confirming. Also, it is impossible to have responsive compatibility with 100% of devices.